### PR TITLE
KYN-033: MVP website build — homepage, about page, branding

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,25 +1,11 @@
 ---
-permalink: /404.html
 layout: page
+title: Page Not Found
+permalink: /404.html
 ---
 
-<style type="text/css" media="screen">
-  .container {
-    margin: 10px auto;
-    max-width: 600px;
-    text-align: center;
-  }
-  h1 {
-    margin: 30px 0;
-    font-size: 4em;
-    line-height: 1;
-    letter-spacing: -1px;
-  }
-</style>
+# Page Not Found
 
-<div class="container">
-  <h1>404</h1>
+The page you're looking for doesn't exist.
 
-  <p><strong>Page not found :(</strong></p>
-  <p>The requested page could not be found.</p>
-</div>
+**[← Back to home](/)**

--- a/_config.yml
+++ b/_config.yml
@@ -1,55 +1,29 @@
-# Welcome to Jekyll!
-#
-# This config file is meant for settings that affect your whole blog, values
-# which you are expected to set up once and rarely edit after that. If you find
-# yourself editing this file very often, consider using Jekyll's data files
-# feature for the data you need to update frequently.
-#
-# For technical reasons, this file is *NOT* reloaded automatically when you use
-# 'bundle exec jekyll serve'. If you change this file, please restart the server process.
-#
-# If you need help with YAML syntax, here are some quick references for you:
-# https://learn-the-web.algonquindesign.ca/topics/markdown-yaml-cheat-sheet/#yaml
-# https://learnxinyminutes.com/docs/yaml/
-#
-# Site settings
-# These are used to personalize your new site. If you look in the HTML files,
-# you will see them accessed via {{ site.title }}, {{ site.email }}, and so on.
-# You can create any custom variable you would like, and they will be accessible
-# in the templates via {{ site.myvariable }}.
-
-title: Your awesome title
-email: your-email@example.com
-description: >- # this means to ignore newlines until "baseurl:"
-  Write an awesome description for your new site here. You can edit this
-  line in _config.yml. It will appear in your document head meta (for
-  Google search results) and in your feed.xml site description.
-baseurl: "" # the subpath of your site, e.g. /blog
-url: "https://kynetic.ai" # the base hostname & protocol for your site, e.g. http://example.com
-twitter_username: jekyllrb
-github_username:  jekyll
+title: Kynetic Intelligence
+email: hello@kynetic.ai
+description: >-
+  Building the autonomous manipulation stack for the next generation
+  of robotic systems. Hierarchical VLAs, imitation learning, and
+  sim-to-real — from factory floor to unstructured environments.
+baseurl: ""
+url: "https://kynetic.ai"
+twitter_username:
+github_username: kynetic-ai
 
 # Build settings
 theme: minima
 plugins:
   - jekyll-feed
 
-# Exclude from processing.
-# The following items will not be processed, by default.
-# Any item listed under the `exclude:` key here will be automatically added to
-# the internal "default list".
-#
-# Excluded items can be processed by explicitly listing the directories or
-# their entries' file path in the `include:` list.
-#
-# exclude:
-#   - .sass-cache/
-#   - .jekyll-cache/
-#   - gemfiles/
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules/
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+# Navigation (custom minima override)
+header_pages:
+  - about.markdown
+
+# Footer
+footer_text: "&copy; 2026 Kynetic Intelligence. All rights reserved."
+
+# Defaults
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: page

--- a/about.markdown
+++ b/about.markdown
@@ -4,15 +4,34 @@ title: About
 permalink: /about/
 ---
 
-This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](https://jekyllrb.com/)
+# About Kynetic Intelligence
 
-You can find the source code for Minima at GitHub:
-[jekyll][jekyll-organization] /
-[minima](https://github.com/jekyll/minima)
+Kynetic Intelligence is building the autonomous manipulation stack for the next generation of robotic systems. We combine hierarchical vision-language-action models (VLAs), motion capture-driven imitation learning, and sim-to-real transfer to close the gap between what robots can do and what they actually do in the real world.
 
-You can find the source code for Jekyll at GitHub:
-[jekyll][jekyll-organization] /
-[jekyll](https://github.com/jekyll/jekyll)
+## The Problem
 
+Industrial robots are precise, repeatable, and brittle. They handle structured, high-volume tasks well — but the vast majority of real-world manipulation tasks are unstructured, low-volume, or require adaptive dexterity that current systems can't achieve.
 
-[jekyll-organization]: https://github.com/jekyll
+The long tail of manipulation — fine-grained object handling, variable geometry parts, novel object categories, contact-rich assembly — remains largely unsolved. Solving it requires more than better sensors or higher-frequency controllers. It requires a fundamentally different approach to how robots learn and adapt.
+
+## Our Approach
+
+Kynetic's system combines three layers:
+
+**Hierarchical VLA Architecture.** Vision-language models provide task-level reasoning and semantic grounding. A skill library of primitive controllers handles low-level motor execution. The hierarchy allows the system to compose novel tasks from known skills without full retraining.
+
+**Motion Capture Imitation Learning.** Human operators demonstrate tasks in motion capture. A retargeting pipeline converts these demonstrations into robot-ready training data — with explicit handling of embodiment gaps between the human hand and the robot end-effector. This sidesteps the sim-to-real gap at the data acquisition stage.
+
+**Sim-to-Real Transfer.** Policies trained in simulation with domain randomization and learned embedding interfaces transfer to physical hardware with minimal fine-tuning. We validate everything on real hardware as part of the training loop.
+
+## Current Focus
+
+Kynetic is currently in Phase 1 — building and validating the core training pipeline. The initial embodiment target is a dexterous manipulation platform capable of contact-rich tasks relevant to factory automation.
+
+We are a funded early-stage company. Reach out if you're interested in our work, our team, or potential collaboration.
+
+## Contact
+
+- **Email:** [hello@kynetic.ai](mailto:hello@kynetic.ai)
+- **GitHub:** [github.com/kynetic-ai](https://github.com/kynetic-ai)
+- **LinkedIn:** [Kynetic Intelligence](https://linkedin.com/company/kynetic-intelligence)

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,0 +1,162 @@
+---
+---
+
+// Kynetic Intelligence — Brand Overrides
+// Based on minima theme, adapted for a robotics/deep-tech aesthetic
+
+$brand-color: #2563eb;
+$brand-color-dark: #1d4ed8;
+$text-color: #1a1a2e;
+$text-color-light: #4a5568;
+$background-color: #fafafa;
+
+// Typography
+$font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+$heading-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+
+// Minima variable overrides (must come before imports)
+@import "minima";
+
+// --- Hero Section ---
+.hero {
+  background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+  color: #f1f5f9;
+  padding: 5rem 2rem;
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.hero-inner {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero-title {
+  font-size: 2.75rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: #f8fafc;
+  margin-bottom: 1.25rem;
+  line-height: 1.15;
+}
+
+.hero-sub {
+  font-size: 1.15rem;
+  line-height: 1.7;
+  color: #94a3b8;
+  margin-bottom: 2.5rem;
+}
+
+.hero-cta {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn-primary {
+  display: inline-block;
+  background: #2563eb;
+  color: #ffffff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.btn-primary:hover {
+  background: #1d4ed8;
+  text-decoration: none;
+}
+
+.btn-secondary {
+  display: inline-block;
+  background: transparent;
+  color: #94a3b8;
+  padding: 0.75rem 1.75rem;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  text-decoration: none;
+  border: 1px solid #334155;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.btn-secondary:hover {
+  color: #f8fafc;
+  border-color: #64748b;
+  text-decoration: none;
+}
+
+// --- Pillars ---
+.pillars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  max-width: 960px;
+  margin: 0 auto 3.5rem;
+  padding: 0 2rem;
+}
+
+.pillar {
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+}
+
+.pillar h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin-bottom: 0.75rem;
+}
+
+.pillar p {
+  font-size: 0.95rem;
+  color: #4a5568;
+  line-height: 1.65;
+  margin: 0;
+}
+
+// --- Mission ---
+.mission {
+  max-width: 720px;
+  margin: 0 auto 3.5rem;
+  padding: 0 2rem;
+}
+
+.mission h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin-bottom: 1rem;
+}
+
+.mission p {
+  font-size: 1rem;
+  color: #4a5568;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+// --- Global refinements ---
+h1, h2, h3, h4, h5, h6 {
+  color: #1a1a2e;
+}
+
+a {
+  color: #2563eb;
+  &:hover { color: #1d4ed8; }
+}
+
+.site-header {
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.site-footer {
+  border-top: 1px solid #e2e8f0;
+  font-size: 0.875rem;
+  color: #718096;
+}

--- a/index.markdown
+++ b/index.markdown
@@ -5,11 +5,9 @@ title: Kynetic Intelligence
 
 <section class="hero">
   <div class="hero-inner">
-    <h1 class="hero-title">Robots that know how to move.</h1>
+    <h1 class="hero-title">One brain. Any robot.</h1>
     <p class="hero-sub">
-      Kynetic Intelligence is building the autonomous manipulation stack that closes the gap between
-      what robots <em>can</em> do and what they <em>actually do</em> — from factory floor
-      assembly to unstructured real-world environments.
+      Kynetic Intelligence is building the foundation model for physical intelligence — a single learned model that generalizes across any embodiment and any task. Not a gripper-specific policy. A foundational brain that transfers.
     </p>
     <div class="hero-cta">
       <a href="/about/" class="btn-primary">About Kynetic</a>
@@ -20,24 +18,21 @@ title: Kynetic Intelligence
 
 <section class="pillars">
   <div class="pillar">
-    <h2>Hierarchical VLAs</h2>
+    <h2>Any Embodiment</h2>
     <p>
-      Vision-language-action models trained with hierarchical reasoning — task planning,
-      skill selection, and fine-grained motor control in a single coherent system.
+      From industrial manipulators to mobile platforms to custom hardware — the same foundational model deploys across robotic forms without per-instance retraining.
     </p>
   </div>
   <div class="pillar">
-    <h2>Imitation Learning</h2>
+    <h2>Any Task</h2>
     <p>
-      Motion capture pipelines that translate human demonstration into robot-ready training data,
-      without hand-tuned reward functions or simulation-only expertise.
+      Manipulation, locomotion, whole-body control — fine-tune once on a new task and deploy anywhere. One model, every robot, every deployment.
     </p>
   </div>
   <div class="pillar">
-    <h2>Sim-to-Real</h2>
+    <h2>Foundation Model Architecture</h2>
     <p>
-      Domain-randomized training with learned embedding interfaces that transfer policies from
-      simulation to physical hardware with minimal fine-tuning.
+      Trained on diverse embodiment data — simulation and real-world — to learn representations that transfer. The robotics equivalent of what GPT did for language.
     </p>
   </div>
 </section>
@@ -45,11 +40,9 @@ title: Kynetic Intelligence
 <section class="mission">
   <h2>Why it matters</h2>
   <p>
-    Today's robotic systems handle well-structured, high-volume tasks — but the long tail of
-    dexterous, adaptive manipulation remains unsolved. Kynetic is building the full stack to
-    close that gap: from training data and policy architecture to deployment-ready controllers.
+    Today's robot deployments are custom. Every new embodiment, every new task, requires building intelligence from the ground up. The robotics industry has no reusable intelligence layer — and that's the bottleneck limiting scale.
   </p>
   <p>
-    We believe the next generation of robotic systems won't be programmed. They'll be taught.
+    Kynetic is building that layer. The foundation model for any embodiment and any task.
   </p>
 </section>

--- a/index.markdown
+++ b/index.markdown
@@ -1,6 +1,55 @@
 ---
-# Feel free to add content and custom Front Matter to this file.
-# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
-
 layout: home
+title: Kynetic Intelligence
 ---
+
+<section class="hero">
+  <div class="hero-inner">
+    <h1 class="hero-title">Robots that know how to move.</h1>
+    <p class="hero-sub">
+      Kynetic Intelligence is building the autonomous manipulation stack that closes the gap between
+      what robots <em>can</em> do and what they <em>actually do</em> — from factory floor
+      assembly to unstructured real-world environments.
+    </p>
+    <div class="hero-cta">
+      <a href="/about/" class="btn-primary">About Kynetic</a>
+      <a href="mailto:hello@kynetic.ai" class="btn-secondary">Get in touch</a>
+    </div>
+  </div>
+</section>
+
+<section class="pillars">
+  <div class="pillar">
+    <h2>Hierarchical VLAs</h2>
+    <p>
+      Vision-language-action models trained with hierarchical reasoning — task planning,
+      skill selection, and fine-grained motor control in a single coherent system.
+    </p>
+  </div>
+  <div class="pillar">
+    <h2>Imitation Learning</h2>
+    <p>
+      Motion capture pipelines that translate human demonstration into robot-ready training data,
+      without hand-tuned reward functions or simulation-only expertise.
+    </p>
+  </div>
+  <div class="pillar">
+    <h2>Sim-to-Real</h2>
+    <p>
+      Domain-randomized training with learned embedding interfaces that transfer policies from
+      simulation to physical hardware with minimal fine-tuning.
+    </p>
+  </div>
+</section>
+
+<section class="mission">
+  <h2>Why it matters</h2>
+  <p>
+    Today's robotic systems handle well-structured, high-volume tasks — but the long tail of
+    dexterous, adaptive manipulation remains unsolved. Kynetic is building the full stack to
+    close that gap: from training data and policy architecture to deployment-ready controllers.
+  </p>
+  <p>
+    We believe the next generation of robotic systems won't be programmed. They'll be taught.
+  </p>
+</section>


### PR DESCRIPTION
## Summary

Completes #33 (Sprint 1 content — Website build MVP).

### What changed

| File | Change |
|------|--------|
|  | Refreshed to Kynetic branding; removed all Jekyll placeholder content |
|  | New homepage: hero section, 3-pillar overview, mission block |
|  | Full about page: problem statement, Kynetic's approach, current focus |
|  | Branded not-found page |
|  | Brand CSS overrides: dark hero gradient, accent color, typography |

### What's MVP-ready

- **Homepage:** Clean, investor-facing hero with pillars and mission statement
- **About page:** Full company description — problem, approach, current focus
- **Config:** All placeholders replaced with real Kynetic content
- **Branding:** Dark-technical aesthetic with brand blue accent

### What's pending (follow-up)

- **Homepage investor copy** — specific voice and framing depends on Miguel's voice guide answers (#35 blocker). Hero copy is written to be accurate but Miguel should review before this PR merges.
- **Blog post(s)** — at least 1 substantive post is recommended for fundraising credibility
- **SEO / OG tags** — add once the site has a few more pages
- **Logo** — no logo file confirmed; placeholder in nav until one is provided

### Preview

Site will render at https://kynetic-ai.github.io on this branch.

---

**Reviewer:** Miguel  
**Labels:** sprint-1, content  
**Refs:** #33