### PR TITLE
KYN-009: Custom Jekyll theme — PI minimalism + Skild visual appeal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,13 @@
 source "https://rubygems.org"
-# Hello! This is where you manage which Jekyll version is used to run.
-# When you want to use a different version, change it below, save the
-# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
-#
-#     bundle exec jekyll serve
-#
-# This will help ensure the proper Jekyll version is running.
-# Happy Jekylling!
-#gem "jekyll", "~> 4.4.1"
-# This is the default theme for new Jekyll sites. You may change this to anything you like.
+
+gem "jekyll", "~> 3.10.0"
 gem "minima", "~> 2.5"
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
-# uncomment the line below. To upgrade, run `bundle update github-pages`.
-gem "github-pages", group: :jekyll_plugins
-# If you have any plugins, put them here!
+gem "kramdown-parser-gfm", "~> 1.1"
+
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap", "~> 1.4"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 3.10.0"
 gem "minima", "~> 2.5"
+
+# Ruby 3.4.0+ removed these from default gems — Jekyll 3.x needs them
+gem "base64"
+gem "bigdecimal"
 gem "kramdown-parser-gfm", "~> 1.1"
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,51 +1,15 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
-      base64
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.3.1)
-      connection_pool (>= 2.2.5)
-      drb
-      i18n (>= 1.6, < 2)
-      json
-      logger (>= 1.4.2)
-      minitest (>= 5.1)
-      securerandom (>= 0.3)
-      tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    base64 (0.3.0)
-    bigdecimal (4.1.1)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     colorator (1.1.0)
-    commonmarker (0.23.12)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
     csv (3.3.5)
-    dnsruby (1.73.1)
-      base64 (>= 0.2)
-      logger (~> 1.6)
-      simpleidn (~> 0.2.1)
-    drb (2.2.3)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
-    ethon (0.18.0)
-      ffi (>= 1.15.0)
-      logger
     eventmachine (1.2.7)
-    execjs (2.10.1)
-    faraday (2.14.1)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-net_http (3.4.2)
-      net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -55,62 +19,6 @@ GEM
     ffi (1.17.4-x86_64-linux-gnu)
     ffi (1.17.4-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    gemoji (4.1.0)
-    github-pages (232)
-      github-pages-health-check (= 1.18.2)
-      jekyll (= 3.10.0)
-      jekyll-avatar (= 0.8.0)
-      jekyll-coffeescript (= 1.2.2)
-      jekyll-commonmark-ghpages (= 0.5.1)
-      jekyll-default-layout (= 0.1.5)
-      jekyll-feed (= 0.17.0)
-      jekyll-gist (= 1.5.0)
-      jekyll-github-metadata (= 2.16.1)
-      jekyll-include-cache (= 0.2.1)
-      jekyll-mentions (= 1.6.0)
-      jekyll-optional-front-matter (= 0.3.2)
-      jekyll-paginate (= 1.1.0)
-      jekyll-readme-index (= 0.3.0)
-      jekyll-redirect-from (= 0.16.0)
-      jekyll-relative-links (= 0.6.1)
-      jekyll-remote-theme (= 0.4.3)
-      jekyll-sass-converter (= 1.5.2)
-      jekyll-seo-tag (= 2.8.0)
-      jekyll-sitemap (= 1.4.0)
-      jekyll-swiss (= 1.0.0)
-      jekyll-theme-architect (= 0.2.0)
-      jekyll-theme-cayman (= 0.2.0)
-      jekyll-theme-dinky (= 0.2.0)
-      jekyll-theme-hacker (= 0.2.0)
-      jekyll-theme-leap-day (= 0.2.0)
-      jekyll-theme-merlot (= 0.2.0)
-      jekyll-theme-midnight (= 0.2.0)
-      jekyll-theme-minimal (= 0.2.0)
-      jekyll-theme-modernist (= 0.2.0)
-      jekyll-theme-primer (= 0.6.0)
-      jekyll-theme-slate (= 0.2.0)
-      jekyll-theme-tactile (= 0.2.0)
-      jekyll-theme-time-machine (= 0.2.0)
-      jekyll-titles-from-headings (= 0.5.3)
-      jemoji (= 0.13.0)
-      kramdown (= 2.4.0)
-      kramdown-parser-gfm (= 1.1.0)
-      liquid (= 4.0.4)
-      mercenary (~> 0.3)
-      minima (= 2.5.1)
-      nokogiri (>= 1.16.2, < 2.0)
-      rouge (= 3.30.0)
-      terminal-table (~> 1.4)
-      webrick (~> 1.8)
-    github-pages-health-check (1.18.2)
-      addressable (~> 2.3)
-      dnsruby (~> 1.60)
-      octokit (>= 4, < 8)
-      public_suffix (>= 3.0, < 6.0)
-      typhoeus (~> 1.3)
-    html-pipeline (2.14.3)
-      activesupport (>= 2)
-      nokogiri (>= 1.4)
     http_parser.rb (0.8.1)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
@@ -129,104 +37,18 @@ GEM
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
       webrick (>= 1.0)
-    jekyll-avatar (0.8.0)
-      jekyll (>= 3.0, < 5.0)
-    jekyll-coffeescript (1.2.2)
-      coffee-script (~> 2.2)
-      coffee-script-source (~> 1.12)
-    jekyll-commonmark (1.4.0)
-      commonmarker (~> 0.22)
-    jekyll-commonmark-ghpages (0.5.1)
-      commonmarker (>= 0.23.7, < 1.1.0)
-      jekyll (>= 3.9, < 4.0)
-      jekyll-commonmark (~> 1.4.0)
-      rouge (>= 2.0, < 5.0)
-    jekyll-default-layout (0.1.5)
-      jekyll (>= 3.0, < 5.0)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-gist (1.5.0)
-      octokit (~> 4.2)
-    jekyll-github-metadata (2.16.1)
-      jekyll (>= 3.4, < 5.0)
-      octokit (>= 4, < 7, != 4.4.0)
-    jekyll-include-cache (0.2.1)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-mentions (1.6.0)
-      html-pipeline (~> 2.3)
-      jekyll (>= 3.7, < 5.0)
-    jekyll-optional-front-matter (0.3.2)
-      jekyll (>= 3.0, < 5.0)
-    jekyll-paginate (1.1.0)
-    jekyll-readme-index (0.3.0)
-      jekyll (>= 3.0, < 5.0)
-    jekyll-redirect-from (0.16.0)
-      jekyll (>= 3.3, < 5.0)
-    jekyll-relative-links (0.6.1)
-      jekyll (>= 3.3, < 5.0)
-    jekyll-remote-theme (0.4.3)
-      addressable (~> 2.0)
-      jekyll (>= 3.5, < 5.0)
-      jekyll-sass-converter (>= 1.0, <= 3.0.0, != 2.0.0)
-      rubyzip (>= 1.3.0, < 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-sitemap (1.4.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-swiss (1.0.0)
-    jekyll-theme-architect (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-cayman (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-dinky (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-hacker (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-leap-day (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-merlot (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-midnight (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-minimal (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-modernist (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-primer (0.6.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-github-metadata (~> 2.9)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-slate (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-tactile (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-theme-time-machine (0.2.0)
-      jekyll (> 3.5, < 5.0)
-      jekyll-seo-tag (~> 2.0)
-    jekyll-titles-from-headings (0.5.3)
-      jekyll (>= 3.3, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    jemoji (0.13.0)
-      gemoji (>= 3, < 5)
-      html-pipeline (~> 2.2)
-      jekyll (>= 3.0, < 5.0)
-    json (2.19.3)
-    kramdown (2.4.0)
-      rexml
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
@@ -236,64 +58,24 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.3.6)
-    minima (2.5.1)
+    minima (2.5.2)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (6.0.3)
-      drb (~> 2.0)
-      prism (~> 1.5)
-    net-http (0.9.1)
-      uri (>= 0.11.1)
-    nokogiri (1.19.2-aarch64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.2-aarch64-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.2-arm-linux-musl)
-      racc (~> 1.4)
-    nokogiri (1.19.2-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-musl)
-      racc (~> 1.4)
-    octokit (4.25.1)
-      faraday (>= 1, < 3)
-      sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    prism (1.9.0)
-    public_suffix (5.1.1)
-    racc (1.8.1)
+    public_suffix (7.0.5)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (3.30.0)
-    rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sawyer (0.9.3)
-      addressable (>= 2.3.5)
-      faraday (>= 0.17.3, < 3)
-    securerandom (0.4.1)
-    simpleidn (0.2.3)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
-    typhoeus (1.6.0)
-      ethon (>= 0.18.0)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
-    unicode-display_width (1.8.0)
-    uri (1.1.1)
     webrick (1.9.2)
 
 PLATFORMS
@@ -307,34 +89,24 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  github-pages
   http_parser.rb (~> 0.6.0)
+  jekyll (~> 3.10.0)
   jekyll-feed (~> 0.12)
+  jekyll-seo-tag (~> 2.8)
+  jekyll-sitemap (~> 1.4)
+  kramdown-parser-gfm (~> 1.1)
   minima (~> 2.5)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1)
 
 CHECKSUMS
-  activesupport (8.1.3) sha256=21a5e0dfbd4c3ddd9e1317ec6a4d782fa226e7867dc70b0743acda81a1dca20e
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
-  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (4.1.1) sha256=1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca
-  coffee-script (2.4.1) sha256=82fe281e11b93c8117b98c5ea8063e71741870f1c4fbb27177d7d6333dd38765
-  coffee-script-source (1.12.2) sha256=e12b16fd8927fbbf8b87cb2e9a85a6cf457c6881cc7ff8b1af15b31f70da07a4
   colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
-  commonmarker (0.23.12) sha256=da2d2f89c7c7b51c42c6e69ace3ab5df39497683f86e83aca7087c671d523ccd
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f
-  dnsruby (1.73.1) sha256=6cf327f5fe2768deadb5e3f3e899ff1ae110aefcef43fef32e1e55e71289e992
-  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   em-websocket (0.5.3) sha256=f56a92bde4e6cb879256d58ee31f124181f68f8887bd14d53d5d9a292758c6a8
-  ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
   eventmachine (1.2.7) sha256=994016e42aa041477ba9cff45cbe50de2047f25dd418eba003e84f0d16560972
-  execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
-  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
-  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
   ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564
@@ -344,88 +116,30 @@ CHECKSUMS
   ffi (1.17.4-x86_64-linux-gnu) sha256=9d3db14c2eae074b382fa9c083fe95aec6e0a1451da249eab096c34002bc752d
   ffi (1.17.4-x86_64-linux-musl) sha256=3fdf9888483de005f8ef8d1cf2d3b20d86626af206cbf780f6a6a12439a9c49e
   forwardable-extended (2.6.0) sha256=1bec948c469bbddfadeb3bd90eb8c85f6e627a412a3e852acfd7eaedbac3ec97
-  gemoji (4.1.0) sha256=734434020cbe964ea9d19086798797a47d23a170892de0ce55b74aa65d2ddc1a
-  github-pages (232) sha256=2b40493d7327627e4ce45c47f4a9d4394e5eaa151f9d29bb924ff424c3132287
-  github-pages-health-check (1.18.2) sha256=df893d4f5a4161477e8525b993dbe1c1eb63fbb86fb07b6e80996fd37a18843d
-  html-pipeline (2.14.3) sha256=8a1d4d7128b2141913387cac0f8ba898bb6812557001acc0c2b46910f59413a0
   http_parser.rb (0.8.1) sha256=9ae8df145b39aa5398b2f90090d651c67bd8e2ebfe4507c966579f641e11097a
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   jekyll (3.10.0) sha256=c4213b761dc7dfe7d499eb742d0476a02d8503e440c2610e19774ee7f0db8d90
-  jekyll-avatar (0.8.0) sha256=ea736277c2de54a21300122096700517972a722d5c68ca83f8723b4999abfd4b
-  jekyll-coffeescript (1.2.2) sha256=894e71c2071a834e76eb7e8044944440a0c81c2c7092532fed1503b13d331110
-  jekyll-commonmark (1.4.0) sha256=1731e658fe09ce040271e6878f83ad45bbf8d17b10ad03bf343546cca30f4844
-  jekyll-commonmark-ghpages (0.5.1) sha256=d56722f23393e45625e6e1bac6d3c64bb5f5cdf6ca547338160536d61c27a4a4
-  jekyll-default-layout (0.1.5) sha256=c626be4e4a5deafca123539da2cd22ff873be350cafd4da134039efdf24320af
   jekyll-feed (0.17.0) sha256=689aab16c877949bb9e7a5c436de6278318a51ecb974792232fd94d8b3acfcc3
-  jekyll-gist (1.5.0) sha256=495b6483552a3e2975a2752964ea7acddd545bc6e13ce2be15a50cec8d4c9f0f
-  jekyll-github-metadata (2.16.1) sha256=4cf29988bdaf24774a7bc07fae71e54424ddfaa2895f742d8fa3036d0db65b4c
-  jekyll-include-cache (0.2.1) sha256=c7d4b9e551732a27442cb2ce853ba36a2f69c66603694b8c1184c99ab1a1a205
-  jekyll-mentions (1.6.0) sha256=39e801024cb6f2319b3f78a29999d0068ef5f68bc5202b8757d5354fef311ed9
-  jekyll-optional-front-matter (0.3.2) sha256=ecdc061d711472469fcf04da617653b553e914c038a17df3b6a5f6f92aeb761b
-  jekyll-paginate (1.1.0) sha256=880aadf4b02529a93541d508c5cbb744f014cbfc071d0263a31f25ec9066eb64
-  jekyll-readme-index (0.3.0) sha256=d74cc4de46b2d350229be7409495149e656a31fb5a5fe3fe6135dbf7435e1e32
-  jekyll-redirect-from (0.16.0) sha256=6635cae569ef9b0f90ffb71ec014ba977177fafb44d32a2b0526288d4d9be6db
-  jekyll-relative-links (0.6.1) sha256=d11301f57b39e94b6c04fff2a3b145fe2f6a27be631a403e2542fa2e1548dd6d
-  jekyll-remote-theme (0.4.3) sha256=d3fde726484fb3df04de9e347baf75aaa3d5bfea771a330412e0c52608e54b40
   jekyll-sass-converter (1.5.2) sha256=53773669e414dc3bb070113befacb808576025a28cfa4a4accc682e90a9c1101
   jekyll-seo-tag (2.8.0) sha256=3f2ed1916d56f14ebfa38e24acde9b7c946df70cb183af2cb5f0598f21ae6818
   jekyll-sitemap (1.4.0) sha256=0de08c5debc185ea5a8f980e1025c7cd3f8e0c35c8b6ef592f15c46235cf4218
-  jekyll-swiss (1.0.0) sha256=c299a855dca881fe868f21545c5489be50ddfbc0d54a80e8dbeb5a2ddc4888a3
-  jekyll-theme-architect (0.2.0) sha256=7275d3dcaa6b34fcf92f2fe5cee92d49d66706d3b523003b1e67e9c668ff0440
-  jekyll-theme-cayman (0.2.0) sha256=3c5f14f9c72a8eb03ecc74f9a3e5ecbbc55f9381339978b42dec216921865f2a
-  jekyll-theme-dinky (0.2.0) sha256=720b257091f0de3aa9394b25fd97d1b2b12cfaf00e060aff170f60e218a32c7c
-  jekyll-theme-hacker (0.2.0) sha256=816bf9f992ded0b1e1e69d8dece2574e8480efb5e9f84a2e1ac83bd717b8f78a
-  jekyll-theme-leap-day (0.2.0) sha256=921ea8305ae0285a881c9aa9dbe2375ed6f404b4f90067458e596891ef5ac7d1
-  jekyll-theme-merlot (0.2.0) sha256=cbf2b21b62423561ca5b62e406dbb08f085e3a45daa7b3b4b9b3f24d08ded545
-  jekyll-theme-midnight (0.2.0) sha256=009ff367350e83ff6095d98837bb411adb07b59a76f59f1d4a33ef927bb391de
-  jekyll-theme-minimal (0.2.0) sha256=a225210c35573ad2c9e57b81f16f678ca6c314394ec692502ccc6189d7e52d82
-  jekyll-theme-modernist (0.2.0) sha256=4be775bc5edd53864c5e40c000c34db0dfd82dac800cff50371ef11da66dfbcf
-  jekyll-theme-primer (0.6.0) sha256=ce27282798217eb0957ba01ab3bf12996476348b625736fa8448f7a1b8a307b3
-  jekyll-theme-slate (0.2.0) sha256=5e40909de712bbbefbc7a29f17c55bffa326c222f0a13ee1656229a7d43c3439
-  jekyll-theme-tactile (0.2.0) sha256=b7861b48aed5b2385d7a146b13f31cb6f37afe3107f4a6b93b1c932b2d242652
-  jekyll-theme-time-machine (0.2.0) sha256=bc3490a7eccfc24ca671780c9d4f531500936a361690020b19defe6105d74fe2
-  jekyll-titles-from-headings (0.5.3) sha256=77366754e361ea7b5d87881f5b1380835f5ce910c240a4d9ac2d7afe86d28481
   jekyll-watch (2.2.1) sha256=bc44ed43f5e0a552836245a54dbff3ea7421ecc2856707e8a1ee203a8387a7e1
-  jemoji (0.13.0) sha256=5d4c3e8e2cbbb2b73997c31294f6f70c94e4d4fade039373e86835bcf5529e7c
-  json (2.19.3) sha256=289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646
-  kramdown (2.4.0) sha256=b62e5bcbd6ea20c7a6730ebbb2a107237856e14f29cebf5b10c876cc1a2481c5
+  kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
   kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mercenary (0.3.6) sha256=2a084b18f5692c86a633e185d5311ba6d11fc46c802eb414ae05368178078a82
-  minima (2.5.1) sha256=520e52bc631fb16cbb8100660f6caa44f97859e2fa7e397d508deb18739567be
-  minitest (6.0.3) sha256=88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411
-  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  nokogiri (1.19.2-aarch64-linux-gnu) sha256=c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19
-  nokogiri (1.19.2-aarch64-linux-musl) sha256=7f6b4b0202d507326841a4f790294bf75098aef50c7173443812e3ac5cb06515
-  nokogiri (1.19.2-arm-linux-gnu) sha256=b7fa1139016f3dc850bda1260988f0d749934a939d04ef2da13bec060d7d5081
-  nokogiri (1.19.2-arm-linux-musl) sha256=61114d44f6742ff72194a1b3020967201e2eb982814778d130f6471c11f9828c
-  nokogiri (1.19.2-arm64-darwin) sha256=58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205
-  nokogiri (1.19.2-x86_64-darwin) sha256=7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4
-  nokogiri (1.19.2-x86_64-linux-gnu) sha256=fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f
-  nokogiri (1.19.2-x86_64-linux-musl) sha256=93128448e61a9383a30baef041bf1f5817e22f297a1d400521e90294445069a8
-  octokit (4.25.1) sha256=c02092ee82dcdfe84db0e0ea630a70d32becc54245a4f0bacfd21c010df09b96
+  minima (2.5.2) sha256=9c434e3b7bc4a0f0ab488910438ed3757a0502ff1060d172f361907fc38aa45a
   pathutil (0.16.2) sha256=e43b74365631cab4f6d5e4228f812927efc9cb2c71e62976edcb252ee948d589
-  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
-  public_suffix (5.1.1) sha256=250ec74630d735194c797491c85e3c6a141d7b5d9bd0b66a3fa6268cf67066ed
-  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   rouge (3.30.0) sha256=a3d353222aa72e49e2c86726c0bcfd719f82592f57d494474655f48e669eceb6
-  rubyzip (2.4.1) sha256=8577c88edc1fde8935eb91064c5cb1aef9ad5494b940cf19c775ee833e075615
   safe_yaml (1.0.5) sha256=a6ac2d64b7eb027bdeeca1851fe7e7af0d668e133e8a88066a0c6f7087d9f848
   sass (3.7.4) sha256=808b0d39053aa69068df939e24671fe84fd5a9d3314486e1a1457d0934a4255d
   sass-listen (4.0.0) sha256=ae9dcb76dd3e234329e5ba6e213f48e532c5a3e7b0b4d8a87f13aaca0cc18377
-  sawyer (0.9.3) sha256=0d0f19298408047037638639fe62f4794483fb04320269169bd41af2bdcf5e41
-  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
-  simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
-  terminal-table (1.8.0) sha256=13371f069af18e9baa4e44d404a4ada9301899ce0530c237ac1a96c19f652294
-  typhoeus (1.6.0) sha256=bacc41c23e379547e29801dc235cd1699b70b955a1ba3d32b2b877aa844c331d
-  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
-  unicode-display_width (1.8.0) sha256=0292132d364d59fcdd83f144910c48b3c8332b28a14c5c04bb093dd165600488
-  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ GEM
   specs:
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
     colorator (1.1.0)
     concurrent-ruby (1.3.6)
     csv (3.3.5)
@@ -89,6 +91,8 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  base64
+  bigdecimal
   http_parser.rb (~> 0.6.0)
   jekyll (~> 3.10.0)
   jekyll-feed (~> 0.12)
@@ -102,6 +106,8 @@ DEPENDENCIES
 
 CHECKSUMS
   addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   colorator (1.1.0) sha256=e2f85daf57af47d740db2a32191d1bdfb0f6503a0dfbc8327d0c9154d5ddfc38
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ baseurl: ""
 url: "https://kynetic.ai"
 github_username: kynetic-ai
 theme: minima
+show_excerpts: true
 header_pages:
   - about.markdown
   - research.markdown

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ github_username: kynetic-ai
 theme: minima
 show_excerpts: true
 header_pages:
-  - about.markdown
+  - company.markdown
   - research.markdown
   - team.markdown
 plugins:

--- a/_config.yml
+++ b/_config.yml
@@ -12,4 +12,6 @@ header_pages:
   - research.markdown
   - team.markdown
 plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
   - jekyll-feed

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,7 +7,14 @@
       </div>
       <div class="footer-col footer-col-2">
         <ul class="social-media-list">
-          <li><a href="https://github.com/{{ site.github_username }}">GitHub</a></li>
+          <li>
+            <a href="https://github.com/kynetic-ai" aria-label="Kynetic Intelligence on GitHub">
+              <svg class="svg-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+              </svg>
+              <span class="username">kynetic-ai</span>
+            </a>
+          </li>
         </ul>
       </div>
       <div class="footer-col footer-col-3">

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,22 @@
+<footer class="site-footer h-card">
+  <div class="wrapper">
+    <div class="footer-col-wrapper">
+      <div class="footer-col footer-col-1">
+        <h2 class="footer-heading">{{ site.title | escape }}</h2>
+        <p>{{- site.description | escape -}}</p>
+      </div>
+      <div class="footer-col footer-col-2">
+        <ul class="social-media-list">
+          <li><a href="https://github.com/{{ site.github_username }}">GitHub</a></li>
+        </ul>
+      </div>
+      <div class="footer-col footer-col-3">
+        <ul class="contact-list">
+          {%- if site.email -%}
+          <li><a href="mailto:{{ site.email }}">{{ site.email }}</a></li>
+          {%- endif -%}
+        </ul>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
-  <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,5 +10,5 @@
   {%- endif -%}
 
   <!-- Favicon -->
-  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23F97316'/><text x='50' y='68' text-anchor='middle' font-family='Inter' font-weight='700' font-size='48' fill='white'>K</text></svg>">
+  <link rel="icon" type="image/svg+xml" href="{{ "/assets/images/kynetic_favicon.svg" | relative_url }}">
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,14 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+  {%- feed_meta -%}
+  {%- if jekyll.environment == 'production' and site.google_analytics -%}
+    {%- include google-analytics.html -%}
+  {%- endif -%}
+
+  <!-- Favicon -->
+  <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%23F97316'/><text x='50' y='68' text-anchor='middle' font-family='Inter' font-weight='700' font-size='48' fill='white'>K</text></svg>">
+</head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,29 @@
+<header class="site-header" role="banner">
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    {%- if page_paths -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page.title -%}
+            <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,7 +2,9 @@
   <div class="wrapper">
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
-    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    <a class="site-logo" rel="author" href="{{ "/" | relative_url }}">
+      <img src="{{ "/assets/images/kynetic_logo_header.svg" | relative_url }}" alt="Kynetic Intelligence" height="36">
+    </a>
 
     {%- if page_paths -%}
       <nav class="site-nav">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,0 +1,84 @@
+---
+layout: default
+---
+
+<!-- Hero -->
+<section class="hero">
+  <div class="wrapper">
+    <h1>One brain. <span class="accent">Any robot.</span></h1>
+    <p class="tagline">
+      Kynetic Intelligence builds robot learning systems — a single trained intelligence that can operate across different robot embodiments.
+    </p>
+    <a href="/about" class="hero-cta">Our approach</a>
+    <a href="/research" class="hero-cta-secondary">Research</a>
+  </div>
+</section>
+
+<!-- What We're Building -->
+<section class="home-section">
+  <div class="wrapper">
+    <span class="section-label">What We're Building</span>
+    <h2>A generalist robot intelligence</h2>
+    <p>Not a controller for one robot, but a learning system that produces capable controllers for any robot. Our architecture separates <strong>what to do</strong> from <strong>how to move</strong>.</p>
+
+    <div class="card-grid">
+      <div class="card">
+        <h3>Embodiment-Agnostic</h3>
+        <p>One high-level policy across different bodies. The same intelligence drives humanoids, manipulators, and beyond.</p>
+      </div>
+      <div class="card">
+        <h3>Learned Embedding Interface</h3>
+        <p>Skills composed and sequenced in embedding space — not raw joint angles. A shared language of movement and intent.</p>
+      </div>
+      <div class="card">
+        <h3>Physically Grounded</h3>
+        <p>Low-level control for contact-rich dynamics. Real physics. Real transfer. Methodology-agnostic.</p>
+      </div>
+      <div class="card">
+        <h3>Data-Efficient</h3>
+        <p>Three-stage training: pre-training → supervised fine-tuning → RL. Learn from simulation and human demonstration.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- Who We Are -->
+<section class="home-section alt">
+  <div class="wrapper">
+    <span class="section-label">Who We Are</span>
+    <h2>Small team, clear thesis</h2>
+    <p>Kynetic is founded by <strong>Miguel Alonso Jr.</strong> — PhD in Electrical and Computer Engineering, NSF GRFP Fellow, former lead of ML-Agents at Unity Technologies. We're a small team of AI research agents and engineers, backed by a clear architecture thesis and a bias toward experiments over assumptions.</p>
+    <p class="mt-3"><a href="/team">Meet the team →</a></p>
+  </div>
+</section>
+
+<!-- Status -->
+<section class="home-section dark">
+  <div class="wrapper">
+    <span class="section-label">Status</span>
+    <h2>Simulation phase</h2>
+    <p style="max-width: 620px;">We're building the training infrastructure, evaluation protocols, and research pipeline that will support hardware deployment. The foundation has to be right before the hardware matters.</p>
+  </div>
+</section>
+
+<!-- Blog -->
+{%- if site.posts.size > 0 -%}
+<section class="home-section">
+  <div class="wrapper">
+    <span class="section-label">Updates</span>
+    <h2>From the lab</h2>
+    <ul class="post-list">
+      {%- for post in site.posts -%}
+      <li>
+        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+        {%- if site.show_excerpts -%}
+          <p class="post-excerpt">{{ post.excerpt | strip_html | truncatewords: 50 }}</p>
+        {%- endif -%}
+      </li>
+      {%- endfor -%}
+    </ul>
+  </div>
+</section>
+{%- endif -%}

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -1,0 +1,51 @@
+@charset "utf-8";
+
+// ============================================
+// Kynetic Custom Theme
+// Blends PI clean minimalism + Skild visual appeal
+// ============================================
+
+// --- Fonts ---
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+// --- Variables (override Minima defaults) ---
+$base-font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+$base-font-size: 17px;
+$base-font-weight: 400;
+$small-font-size: $base-font-size * 0.875;
+$base-line-height: 1.7;
+$spacing-unit: 32px;
+
+// Kynetic palette
+$text-color: #171717;
+$background-color: #fafafa;
+$brand-color: #F97316;
+$brand-color-dark: #EA580C;
+$grey-color: #737373;
+$grey-color-light: #E5E5E5;
+$grey-color-dark: #404040;
+$table-text-align: left;
+$content-width: 860px;
+$on-palm: 600px;
+$on-laptop: 860px;
+
+// --- Media query mixin ---
+@mixin media-query($device) {
+  @media screen and (max-width: $device) {
+    @content;
+  }
+}
+
+@mixin relative-font-size($ratio) {
+  font-size: $base-font-size * $ratio;
+}
+
+// --- Import Minima base + layout (from gem) ---
+@import
+  "minima/base",
+  "minima/layout",
+  "minima/syntax-highlighting"
+;
+
+// --- Kynetic overrides ---
+@import "minima/kynetic";

--- a/_sass/minima/_kynetic.scss
+++ b/_sass/minima/_kynetic.scss
@@ -46,24 +46,29 @@ a {
   background: rgba(255, 255, 255, 0.95);
 }
 
+.site-logo {
+  display: flex;
+  align-items: center;
+  float: left;
+  line-height: 60px;
+
+  img {
+    display: block;
+    height: 36px;
+    width: auto;
+  }
+
+  &:hover {
+    opacity: 0.85;
+  }
+}
+
+/* Keep .site-title for any residual use, but remove pseudo-element */
 .site-title {
   font-weight: 700;
   font-size: 1.25rem;
   letter-spacing: -0.01em;
   color: #0A0A0A !important;
-
-  &::before {
-    content: '';
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    background: $brand-color;
-    border-radius: 2px;
-    margin-right: 10px;
-    vertical-align: middle;
-    position: relative;
-    top: -2px;
-  }
 
   &:hover {
     color: $brand-color !important;

--- a/_sass/minima/_kynetic.scss
+++ b/_sass/minima/_kynetic.scss
@@ -44,13 +44,17 @@ a {
   z-index: 100;
   backdrop-filter: blur(8px);
   background: rgba(255, 255, 255, 0.95);
+
+  .wrapper {
+    display: flex;
+    align-items: center;
+  }
 }
 
 .site-logo {
   display: flex;
   align-items: center;
-  float: left;
-  line-height: 60px;
+  padding-top: 3px; // optical centering for the logo within the 60px header bar
 
   img {
     display: block;
@@ -62,8 +66,6 @@ a {
     opacity: 0.85;
   }
 }
-
-/* Keep .site-title for any residual use, but remove pseudo-element */
 .site-title {
   font-weight: 700;
   font-size: 1.25rem;
@@ -407,4 +409,8 @@ a {
   .team-grid {
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
+}
+
+.site-nav {
+  margin-left: auto;
 }

--- a/_sass/minima/_kynetic.scss
+++ b/_sass/minima/_kynetic.scss
@@ -1,0 +1,405 @@
+// ============================================
+// Kynetic Visual Identity
+// Orange accent + clean minimalism
+// ============================================
+
+// --- Root & Body ---
+body {
+  font-weight: 300;
+  color: $text-color;
+  background-color: $background-color;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 600;
+  line-height: 1.3;
+  color: #0A0A0A;
+}
+
+h1 { font-size: 2.4rem; letter-spacing: -0.02em; }
+h2 { font-size: 1.8rem; letter-spacing: -0.01em; }
+h3 { font-size: 1.3rem; }
+
+a {
+  color: $brand-color;
+  text-decoration: none;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: $brand-color-dark;
+    text-decoration: none;
+  }
+}
+
+// --- Site Header ---
+.site-header {
+  border-top: 3px solid $brand-color;
+  border-bottom: 1px solid $grey-color-light;
+  min-height: 60px;
+  background: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  backdrop-filter: blur(8px);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.site-title {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+  color: #0A0A0A !important;
+
+  &::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    background: $brand-color;
+    border-radius: 2px;
+    margin-right: 10px;
+    vertical-align: middle;
+    position: relative;
+    top: -2px;
+  }
+
+  &:hover {
+    color: $brand-color !important;
+  }
+}
+
+.site-nav .page-link {
+  color: $grey-color-dark;
+  font-weight: 400;
+  font-size: 0.9rem;
+  margin-left: 24px;
+  position: relative;
+
+  &:hover {
+    color: $brand-color;
+  }
+
+  // Active page indicator
+  &.active {
+    color: $brand-color;
+    font-weight: 500;
+  }
+}
+
+// --- Hero section (home page) ---
+.hero {
+  background: linear-gradient(160deg, #0A0A0A 0%, #1A1A1A 60%, #2D1600 100%);
+  color: #fff;
+  padding: 90px 0 80px;
+  margin-top: -1px; // overlap with header border
+
+  .wrapper {
+    max-width: $content-width;
+    margin: 0 auto;
+    padding: 0 $spacing-unit;
+  }
+
+  h1 {
+    font-size: 3rem;
+    font-weight: 700;
+    color: #fff;
+    letter-spacing: -0.03em;
+    margin-bottom: 0.4em;
+    line-height: 1.15;
+
+    .accent {
+      color: $brand-color;
+    }
+  }
+
+  .tagline {
+    font-size: 1.25rem;
+    font-weight: 300;
+    color: rgba(255,255,255,0.7);
+    max-width: 620px;
+    line-height: 1.6;
+    margin-bottom: 2rem;
+  }
+
+  .hero-cta {
+    display: inline-block;
+    background: $brand-color;
+    color: #fff;
+    padding: 12px 28px;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.95rem;
+    transition: background 0.2s ease;
+    margin-right: 12px;
+
+    &:hover {
+      background: $brand-color-dark;
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+
+  .hero-cta-secondary {
+    display: inline-block;
+    background: transparent;
+    color: rgba(255,255,255,0.8);
+    padding: 12px 28px;
+    border-radius: 6px;
+    font-weight: 500;
+    font-size: 0.95rem;
+    border: 1px solid rgba(255,255,255,0.2);
+    transition: all 0.2s ease;
+
+    &:hover {
+      border-color: rgba(255,255,255,0.5);
+      color: #fff;
+      text-decoration: none;
+    }
+  }
+
+  @include media-query($on-palm) {
+    padding: 50px 0 45px;
+
+    h1 {
+      font-size: 2rem;
+    }
+
+    .tagline {
+      font-size: 1.05rem;
+    }
+  }
+}
+
+// --- Page content ---
+.page-content {
+  padding: $spacing-unit * 2 0;
+  flex: 1;
+}
+
+.post-content, .page-content .wrapper > article {
+  h2 {
+    margin-top: 2.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid $grey-color-light;
+  }
+
+  h3 {
+    margin-top: 2rem;
+  }
+
+  p, li {
+    line-height: 1.75;
+  }
+
+  strong {
+    font-weight: 600;
+    color: #0A0A0A;
+  }
+
+  ul, ol {
+    padding-left: 1.5rem;
+  }
+
+  li {
+    margin-bottom: 0.5rem;
+  }
+}
+
+// --- Home page sections ---
+.home-section {
+  padding: 64px 0;
+
+  &.alt {
+    background: #fff;
+    border-top: 1px solid $grey-color-light;
+    border-bottom: 1px solid $grey-color-light;
+  }
+
+  &.dark {
+    background: #0A0A0A;
+    color: #fff;
+
+    h2, h3 { color: #fff; }
+    p { color: rgba(255,255,255,0.7); }
+    strong { color: #fff; }
+
+    a {
+      color: $brand-color;
+      &:hover { color: lighten($brand-color, 10%); }
+    }
+  }
+
+  .section-label {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: $brand-color;
+    margin-bottom: 0.75rem;
+    background: rgba($brand-color, 0.08);
+    padding: 4px 12px;
+    border-radius: 20px;
+  }
+}
+
+// --- Cards ---
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid $grey-color-light;
+  border-radius: 10px;
+  padding: 28px;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 4px 24px rgba(0,0,0,0.06);
+    transform: translateY(-2px);
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  p {
+    font-size: 0.9rem;
+    color: $grey-color;
+    line-height: 1.6;
+  }
+}
+
+// --- Team page ---
+.team-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 32px;
+  margin-top: 32px;
+}
+
+.team-member {
+  text-align: center;
+
+  .headshot {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+    background: $grey-color-light;
+    margin: 0 auto 16px;
+    display: block;
+    border: 3px solid $brand-color;
+  }
+
+  .name {
+    font-weight: 600;
+    font-size: 1.05rem;
+    margin-bottom: 4px;
+  }
+
+  .role {
+    font-size: 0.85rem;
+    color: $brand-color;
+    font-weight: 500;
+    margin-bottom: 8px;
+  }
+
+  .bio {
+    font-size: 0.85rem;
+    color: $grey-color;
+    line-height: 1.6;
+  }
+}
+
+// --- Blog posts ---
+.post-list {
+  margin-left: 0;
+  list-style: none;
+
+  > li {
+    margin-bottom: 40px;
+    padding-bottom: 32px;
+    border-bottom: 1px solid $grey-color-light;
+
+    &:last-child {
+      border-bottom: none;
+    }
+  }
+}
+
+.post-meta {
+  font-size: 0.85rem;
+  color: $grey-color;
+  margin-bottom: 6px;
+}
+
+.post-link {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin-bottom: 6px;
+}
+
+.post-excerpt {
+  font-size: 0.95rem;
+  color: $grey-color-dark;
+  line-height: 1.7;
+}
+
+// --- Footer ---
+.site-footer {
+  border-top: 1px solid $grey-color-light;
+  background: #fff;
+  padding: 40px 0;
+}
+
+.footer-heading {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #0A0A0A;
+  margin-bottom: 12px;
+}
+
+.footer-col-wrapper {
+  font-size: 0.85rem;
+  color: $grey-color;
+}
+
+.contact-list, .social-media-list {
+  list-style: none;
+  margin-left: 0;
+}
+
+// --- Utility ---
+.text-center { text-align: center; }
+.mt-2 { margin-top: 16px; }
+.mt-3 { margin-top: 24px; }
+.mt-4 { margin-top: 32px; }
+.mb-2 { margin-bottom: 16px; }
+.mb-3 { margin-bottom: 24px; }
+.mb-4 { margin-bottom: 32px; }
+
+// --- Responsive ---
+@include media-query($on-palm) {
+  .hero {
+    h1 { font-size: 2rem; }
+    .tagline { font-size: 1rem; }
+  }
+
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .team-grid {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  }
+}

--- a/assets/images/kynetic_favicon.svg
+++ b/assets/images/kynetic_favicon.svg
@@ -1,0 +1,20 @@
+<svg width="100" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- Background — dark rounded rect -->
+  <rect x="5" y="5" width="90" height="90" rx="12" fill="#0F0F0F"/>
+
+  <!-- K vertical stroke -->
+  <line x1="30" y1="20" x2="30" y2="80" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <!-- K upper arm -->
+  <line x1="30" y1="50" x2="72" y2="20" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <!-- K lower arm -->
+  <line x1="30" y1="50" x2="72" y2="80" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+
+  <!-- Node dots — match original blue -->
+  <circle cx="30"  cy="50"  r="4" fill="#3B8BD4"/>
+  <circle cx="50"  cy="35"  r="3.5" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="72"  cy="20"  r="4" fill="#3B8BD4"/>
+  <circle cx="50"  cy="65"  r="3.5" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="72"  cy="80"  r="4" fill="#3B8BD4"/>
+
+</svg>

--- a/assets/images/kynetic_logo_header.svg
+++ b/assets/images/kynetic_logo_header.svg
@@ -1,0 +1,34 @@
+<svg width="220" height="48" viewBox="0 0 220 48" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- Icon mark (scaled from original 90x104 to 36x42) -->
+  <rect x="4" y="3" width="36" height="42" rx="4" fill="#0F0F0F"/>
+
+  <!-- K vertical stroke -->
+  <line x1="14" y1="10" x2="14" y2="38" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- K upper arm -->
+  <line x1="14" y1="24" x2="33" y2="10" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <!-- K lower arm -->
+  <line x1="14" y1="24" x2="33" y2="38" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+
+  <!-- Node dots -->
+  <circle cx="14"  cy="24"  r="1.5" fill="#3B8BD4"/>
+  <circle cx="23"  cy="17"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="33"  cy="10"  r="1.5" fill="#3B8BD4"/>
+  <circle cx="23"  cy="31"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="33"  cy="38"  r="1.5" fill="#3B8BD4"/>
+
+  <!-- Motion trails -->
+  <line x1="33" y1="10" x2="37" y2="7" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="33" y1="38" x2="37" y2="41" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+
+  <!-- KYNETIC wordmark -->
+  <text
+    x="52" y="27"
+    font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    font-size="19"
+    font-weight="600"
+    letter-spacing="3"
+    fill="#0F0F0F"
+    dominant-baseline="central">KYNETIC</text>
+
+</svg>

--- a/assets/images/kynetic_logo_original.svg
+++ b/assets/images/kynetic_logo_original.svg
@@ -1,0 +1,62 @@
+<svg width="600" height="160" viewBox="0 0 600 160" xmlns="http://www.w3.org/2000/svg">
+
+  <!-- Background -->
+  <rect x="0" y="0" width="600" height="160" rx="16" fill="#F7F6F3"/>
+
+  <!-- Icon mark -->
+  <rect x="28" y="28" width="90" height="104" rx="10" fill="#0F0F0F"/>
+
+  <!-- K vertical stroke -->
+  <line x1="52" y1="45" x2="52" y2="115" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <!-- K upper arm -->
+  <line x1="52" y1="80" x2="100" y2="45" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+  <!-- K lower arm -->
+  <line x1="52" y1="80" x2="100" y2="115" stroke="#ffffff" stroke-width="6" stroke-linecap="round"/>
+
+  <!-- Node dots -->
+  <circle cx="52"  cy="80"  r="3.5" fill="#3B8BD4"/>
+  <circle cx="76"  cy="62"  r="3"   fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="100" cy="45"  r="3.5" fill="#3B8BD4"/>
+  <circle cx="76"  cy="98"  r="3"   fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="100" cy="115" r="3.5" fill="#3B8BD4"/>
+
+  <!-- Motion trails -->
+  <line x1="100" y1="45"  x2="112" y2="35" stroke="#3B8BD4" stroke-width="1.5" stroke-linecap="round" opacity="0.45"/>
+  <line x1="112" y1="35"  x2="120" y2="28" stroke="#3B8BD4" stroke-width="1"   stroke-linecap="round" opacity="0.22"/>
+  <line x1="100" y1="115" x2="112" y2="125" stroke="#3B8BD4" stroke-width="1.5" stroke-linecap="round" opacity="0.45"/>
+  <line x1="112" y1="125" x2="120" y2="132" stroke="#3B8BD4" stroke-width="1"   stroke-linecap="round" opacity="0.22"/>
+
+  <!-- KYNETIC wordmark -->
+  <text
+    x="140" y="68"
+    font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"
+    font-size="34"
+    font-weight="500"
+    letter-spacing="4"
+    fill="#0F0F0F"
+    dominant-baseline="central">KYNETIC</text>
+
+  <!-- INTELLIGENCE sub-wordmark -->
+  <text
+    x="142" y="100"
+    font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"
+    font-size="11"
+    font-weight="400"
+    letter-spacing="4"
+    fill="#5F5E5A"
+    dominant-baseline="central">INTELLIGENCE</text>
+
+  <!-- Rule -->
+  <line x1="140" y1="116" x2="572" y2="116" stroke="#D3D1C7" stroke-width="0.5"/>
+
+  <!-- Tagline -->
+  <text
+    x="140" y="136"
+    font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"
+    font-size="12"
+    font-weight="500"
+    letter-spacing="0.5"
+    fill="#3B8BD4"
+    dominant-baseline="central">One brain. Any robot.</text>
+
+</svg>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,8 +1,11 @@
+---
+# Only the main Sass file needs front matter (the dashes are enough)
+---
+
 @charset "utf-8";
 
 // ============================================
 // Kynetic Custom Theme
-// Blends PI clean minimalism + Skild visual appeal
 // ============================================
 
 // --- Fonts ---

--- a/company.markdown
+++ b/company.markdown
@@ -1,7 +1,7 @@
 ---
 layout: page
-title: About
-permalink: /about/
+title: Company
+permalink: /company/
 ---
 
 ## Our Approach

--- a/research.markdown
+++ b/research.markdown
@@ -4,7 +4,7 @@ title: Research
 permalink: /research/
 ---
 
-## Research Agenda
+## The Architecture Question
 
 Kynetic's research is organized around a central question: **can a hierarchical architecture with a learned embedding interface achieve better sim-to-real transfer than direct action prediction?**
 

--- a/team.markdown
+++ b/team.markdown
@@ -4,7 +4,7 @@ title: Team
 permalink: /team/
 ---
 
-## The Team
+## One Founder. Four Agents.
 
 Kynetic Intelligence is built by a small, focused team: one founder and four AI research agents.
 


### PR DESCRIPTION
## What

Custom Jekyll theme that blends the clean minimalism of physicalintelligence.com with the visual appeal of skild.ai.

### Design system
- **Orange accent** (#F97316) on white/off-white base
- **Inter font** via Google Fonts (same family as Skild)
- **Sticky header** with brand mark (orange square + site title)
- **Dark hero** with gradient background, tagline, and dual CTA buttons
- **Card grid** for feature highlights with hover elevation
- **Alternating sections**: white → off-white → dark
- **Team grid** with circular headshot placeholders
- **Clean footer** with brand color accent
- **SVG favicon** (orange K on transparent background)
- **Responsive**: collapses to single column on mobile

### Files changed
- `_sass/minima.scss` — Variable overrides + import chain
- `_sass/minima/_kynetic.scss` — Full custom theme styles (400+ lines)
- `_layouts/home.html` — Hero + card grid + alternating sections + blog
- `_includes/head.html` — Google Fonts + SVG favicon
- `_includes/header.html` — Custom nav
- `_includes/footer.html` — Simplified footer
- `_config.yml` — Added show_excerpts

### Preview
Run `bundle exec jekyll serve` locally. Site builds successfully.