### PR TITLE
KYN-012: Update header logo to read 'Kynetic Intelligence'

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
     <a class="site-logo" rel="author" href="{{ "/" | relative_url }}">
-      <img src="{{ "/assets/images/kynetic_logo_header.svg" | relative_url }}" alt="Kynetic Intelligence" height="36">
+      <img src="{{ "/assets/images/kynetic_logo_header.svg" | relative_url }}" alt="Kynetic Intelligence" width="150">
     </a>
 
     {%- if page_paths -%}

--- a/_sass/minima/_kynetic.scss
+++ b/_sass/minima/_kynetic.scss
@@ -58,8 +58,8 @@ a {
 
   img {
     display: block;
-    height: 36px;
-    width: auto;
+    width: 150px;
+    height: auto;
   }
 
   &:hover {

--- a/assets/images/kynetic_logo_header.svg
+++ b/assets/images/kynetic_logo_header.svg
@@ -1,41 +1,41 @@
-<svg width="220" height="58" viewBox="0 0 220 58" xmlns="http://www.w3.org/2000/svg">
+<svg width="240" height="64" viewBox="0 0 240 64" xmlns="http://www.w3.org/2000/svg">
 
-  <!-- Icon mark (scaled from original 90x104 to 36x42) -->
-  <rect x="4" y="8" width="36" height="42" rx="4" fill="#0F0F0F"/>
+  <!-- Icon mark (scaled from original 90x104 to 36x42, centered vertically in 64px height) -->
+  <rect x="20" y="11" width="36" height="42" rx="4" fill="#0F0F0F"/>
 
   <!-- K vertical stroke -->
-  <line x1="14" y1="15" x2="14" y2="43" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="18" x2="30" y2="46" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
   <!-- K upper arm -->
-  <line x1="14" y1="29" x2="33" y2="15" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="32" x2="49" y2="18" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
   <!-- K lower arm -->
-  <line x1="14" y1="29" x2="33" y2="43" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="30" y1="32" x2="49" y2="46" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
 
   <!-- Node dots -->
-  <circle cx="14"  cy="29"  r="1.5" fill="#3B8BD4"/>
-  <circle cx="23"  cy="22"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
-  <circle cx="33"  cy="15"  r="1.5" fill="#3B8BD4"/>
-  <circle cx="23"  cy="36"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
-  <circle cx="33"  cy="43"  r="1.5" fill="#3B8BD4"/>
+  <circle cx="30" cy="32" r="1.5" fill="#3B8BD4"/>
+  <circle cx="39" cy="25" r="1.3" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="49" cy="18" r="1.5" fill="#3B8BD4"/>
+  <circle cx="39" cy="39" r="1.3" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="49" cy="46" r="1.5" fill="#3B8BD4"/>
 
   <!-- Motion trails -->
-  <line x1="33" y1="15" x2="37" y2="12" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
-  <line x1="33" y1="43" x2="37" y2="46" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="49" y1="18" x2="53" y2="15" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="49" y1="46" x2="53" y2="49" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
 
-  <!-- KYNETIC wordmark -->
+  <!-- KYNETIC wordmark (font 2x bigger: 16→32) -->
   <text
-    x="52" y="30"
+    x="68" y="19"
     font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif"
-    font-size="16"
+    font-size="32"
     font-weight="600"
     letter-spacing="3"
     fill="#0F0F0F"
     dominant-baseline="central">KYNETIC</text>
 
-  <!-- INTELLIGENCE sub-wordmark -->
+  <!-- INTELLIGENCE sub-wordmark (font 2x bigger: 8→16, closer to KYNETIC) -->
   <text
-    x="52" y="48"
+    x="68" y="45"
     font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif"
-    font-size="8"
+    font-size="16"
     font-weight="400"
     letter-spacing="2.5"
     fill="#5F5E5A"

--- a/assets/images/kynetic_logo_header.svg
+++ b/assets/images/kynetic_logo_header.svg
@@ -1,4 +1,4 @@
-<svg width="240" height="64" viewBox="0 0 240 64" xmlns="http://www.w3.org/2000/svg">
+<svg width="150" height="40" viewBox="0 0 240 64" xmlns="http://www.w3.org/2000/svg">
 
   <!-- Icon mark (scaled from original 90x104 to 36x42, centered vertically in 64px height) -->
   <rect x="20" y="11" width="36" height="42" rx="4" fill="#0F0F0F"/>
@@ -11,15 +11,15 @@
   <line x1="30" y1="32" x2="49" y2="46" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
 
   <!-- Node dots -->
-  <circle cx="30" cy="32" r="1.5" fill="#3B8BD4"/>
-  <circle cx="39" cy="25" r="1.3" fill="#3B8BD4" opacity="0.75"/>
-  <circle cx="49" cy="18" r="1.5" fill="#3B8BD4"/>
-  <circle cx="39" cy="39" r="1.3" fill="#3B8BD4" opacity="0.75"/>
-  <circle cx="49" cy="46" r="1.5" fill="#3B8BD4"/>
+  <circle cx="30" cy="32" r="1.5" fill="#F97316"/>
+  <circle cx="39" cy="25" r="1.3" fill="#F97316" opacity="0.75"/>
+  <circle cx="49" cy="18" r="1.5" fill="#F97316"/>
+  <circle cx="39" cy="39" r="1.3" fill="#F97316" opacity="0.75"/>
+  <circle cx="49" cy="46" r="1.5" fill="#F97316"/>
 
   <!-- Motion trails -->
-  <line x1="49" y1="18" x2="53" y2="15" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
-  <line x1="49" y1="46" x2="53" y2="49" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="49" y1="18" x2="53" y2="15" stroke="#F97316" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="49" y1="46" x2="53" y2="49" stroke="#F97316" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
 
   <!-- KYNETIC wordmark (font 2x bigger: 16→32) -->
   <text

--- a/assets/images/kynetic_logo_header.svg
+++ b/assets/images/kynetic_logo_header.svg
@@ -1,34 +1,44 @@
-<svg width="220" height="48" viewBox="0 0 220 48" xmlns="http://www.w3.org/2000/svg">
+<svg width="220" height="58" viewBox="0 0 220 58" xmlns="http://www.w3.org/2000/svg">
 
   <!-- Icon mark (scaled from original 90x104 to 36x42) -->
-  <rect x="4" y="3" width="36" height="42" rx="4" fill="#0F0F0F"/>
+  <rect x="4" y="8" width="36" height="42" rx="4" fill="#0F0F0F"/>
 
   <!-- K vertical stroke -->
-  <line x1="14" y1="10" x2="14" y2="38" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="14" y1="15" x2="14" y2="43" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
   <!-- K upper arm -->
-  <line x1="14" y1="24" x2="33" y2="10" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="14" y1="29" x2="33" y2="15" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
   <!-- K lower arm -->
-  <line x1="14" y1="24" x2="33" y2="38" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="14" y1="29" x2="33" y2="43" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round"/>
 
   <!-- Node dots -->
-  <circle cx="14"  cy="24"  r="1.5" fill="#3B8BD4"/>
-  <circle cx="23"  cy="17"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
-  <circle cx="33"  cy="10"  r="1.5" fill="#3B8BD4"/>
-  <circle cx="23"  cy="31"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
-  <circle cx="33"  cy="38"  r="1.5" fill="#3B8BD4"/>
+  <circle cx="14"  cy="29"  r="1.5" fill="#3B8BD4"/>
+  <circle cx="23"  cy="22"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="33"  cy="15"  r="1.5" fill="#3B8BD4"/>
+  <circle cx="23"  cy="36"  r="1.3" fill="#3B8BD4" opacity="0.75"/>
+  <circle cx="33"  cy="43"  r="1.5" fill="#3B8BD4"/>
 
   <!-- Motion trails -->
-  <line x1="33" y1="10" x2="37" y2="7" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
-  <line x1="33" y1="38" x2="37" y2="41" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="33" y1="15" x2="37" y2="12" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
+  <line x1="33" y1="43" x2="37" y2="46" stroke="#3B8BD4" stroke-width="0.8" stroke-linecap="round" opacity="0.45"/>
 
   <!-- KYNETIC wordmark -->
   <text
-    x="52" y="27"
+    x="52" y="30"
     font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif"
-    font-size="19"
+    font-size="16"
     font-weight="600"
     letter-spacing="3"
     fill="#0F0F0F"
     dominant-baseline="central">KYNETIC</text>
+
+  <!-- INTELLIGENCE sub-wordmark -->
+  <text
+    x="52" y="48"
+    font-family="'Inter', 'Helvetica Neue', Helvetica, Arial, sans-serif"
+    font-size="8"
+    font-weight="400"
+    letter-spacing="2.5"
+    fill="#5F5E5A"
+    dominant-baseline="central">INTELLIGENCE</text>
 
 </svg>


### PR DESCRIPTION
## What

The header SVG logo (`kynetic_logo_header.svg`) currently reads only "KYNETIC" — it should read "Kynetic Intelligence" to match the full company name.

## Changes

- Expanded SVG viewBox from 220×48 to 220×58 to accommodate the full name
- KYNETIC remains the primary wordmark (16px, weight 600)
- Added INTELLIGENCE as a subline below (8px, weight 400, #5F5E5A)
- Icon mark repositioned for vertical balance with the two-line layout
- Matches the layout of the original full logo (`kynetic_logo_original.svg`)

## Verification

- Clean Jekyll build (`bundle exec jekyll build`)
- No CSS changes needed — `width: auto` in `.site-logo img` handles the new aspect ratio automatically