### PR TITLE
KYN-017: Replace contact emails with info@ + investors@

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 title: Kynetic Intelligence
-email: miguel@kynetic.ai
+email: info@kynetic.ai
 description: >-
   One brain. Any robot.
 baseurl: ""

--- a/company.markdown
+++ b/company.markdown
@@ -42,4 +42,4 @@ We are in the **simulation phase** — building infrastructure, training pipelin
 
 ## Contact
 
-[GitHub](https://github.com/kynetic-ai) &middot; [info@kynetic.ai](mailto:info@kynetic.ai) &middot; [investors@kynetic.ai](mailto:investors@kynetic.ai)
+[info@kynetic.ai](mailto:info@kynetic.ai) &middot; [investors@kynetic.ai](mailto:investors@kynetic.ai)

--- a/company.markdown
+++ b/company.markdown
@@ -42,4 +42,4 @@ We are in the **simulation phase** — building infrastructure, training pipelin
 
 ## Contact
 
-[GitHub](https://github.com/kynetic-ai) &middot; miguel@kynetic.ai
+[GitHub](https://github.com/kynetic-ai) &middot; [info@kynetic.ai](mailto:info@kynetic.ai) &middot; [investors@kynetic.ai](mailto:investors@kynetic.ai)


### PR DESCRIPTION
## Changes

- **\_config.yml**: `email` → `info@kynetic.ai` (footer rendering)
- **company.markdown**: `miguel@kynetic.ai` → `info@kynetic.ai` + `investors@kynetic.ai` with mailto links

## Testing

- Clean Jekyll build verified