### PR TITLE
KYN-020: Add Blog page + nav menu item

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,7 @@ github_username: kynetic-ai
 theme: minima
 show_excerpts: true
 header_pages:
+  - blog.markdown
   - company.markdown
   - research.markdown
   - team.markdown

--- a/blog.markdown
+++ b/blog.markdown
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Blog
+permalink: /blog/
+---
+
+<p class="blog-intro">Technical notes, experiment results, and reflections from the lab.</p>
+
+{%- if site.posts.size > 0 -%}
+<ul class="post-list">
+  {%- for post in site.posts -%}
+  <li>
+    {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
+    <span class="post-meta">{{ post.date | date: date_format }}</span>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
+    </h3>
+    {%- if site.show_excerpts -%}
+      <p class="post-excerpt">{{ post.excerpt | strip_html | truncatewords: 75 }}</p>
+    {%- endif -%}
+  </li>
+  {%- endfor -%}
+</ul>
+
+<p class="rss-subscribe">Subscribe <a href="{{ "/feed.xml" | relative_url }}">via RSS</a></p>
+{%- else -%}
+<p>No posts yet. Check back soon.</p>
+{%- endif -%}


### PR DESCRIPTION
## Changes
- Create `blog.markdown` with dedicated blog listing page (permalink: /blog/)
- Full post listing: date, title, excerpt for each post
- RSS subscribe link at bottom
- Add `blog.markdown` to `header_pages` in `_config.yml` (first in nav order)

## Verification
- `bundle exec jekyll build` succeeds cleanly

## Screenshot
The blog page iterates over `site.posts` using the same post-list markup pattern as the home page updates section. Currently shows one post ("Hello, Robot!"). The embedding interface post (PR #11) will appear here once merged.